### PR TITLE
Allow running without being root. using capabilities instead.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,11 +6,13 @@ Build-Depends: debhelper (>= 9),
          debconf (>= 0.2.26),
          ti-pru-cgt-installer,
          pru-software-support-package,
+         libcap2-dev,
 Standards-Version: 3.9.5
 Maintainer: James Strawson <james@strawsondesign.com>
 Homepage: <www.strawsondesign.com>
 
 Package: roboticscape
 Architecture: armhf
+Depends: libcap2
 Description: Robotics Cape Library and Examples
 	Supporting library and example programs for the Robotics Cape and Beaglebone Blue

--- a/libraries/Makefile
+++ b/libraries/Makefile
@@ -10,7 +10,7 @@ ARCFLAGS	:= -mfpu=neon -mfloat-abi=hard -march=armv7-a -mtune=cortex-a8
 # enable O3 optimization and vectorized math
 FFLAGS		:= -O3 -ffast-math -ftree-vectorize
 CFLAGS		:= -c -fPIC
-LFLAGS		:= -lm -lrt -lpthread -shared -Wl,-soname,$(TARGET)
+LFLAGS		:= -lm -lrt -lpthread -lcap -shared -Wl,-soname,$(TARGET)
 
 SOURCES		:= $(shell find ./ -name '*.c')
 INCLUDES	:= $(shell find ./ -name '*.h')


### PR DESCRIPTION
This adds dependency with libcap2
This adds build-dependency with libcap-dev
To add capabilities to binaries libcap2-bin is required ( because of setcap )

```
sudo apt install libcap2-bin
sudo setcap cap_sys_rawio,cap_dac_override+epi sailsys
```

Allow rc_initialize to keep on going when user is not root, but process has the required capabilities.